### PR TITLE
Extend Signature Handling with Timestamp Support

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/BouncySigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/BouncySigner.cs
@@ -28,8 +28,10 @@ namespace PdfSharp.Pdf.Signatures
             this.CertificateChain = certificateData.Item2;
         }
 
-        public byte[] GetSignedCms(Stream rangedStream, int pdfVersion)
+        public byte[] GetSignedCms(Stream rangedStream, int pdfVersion, byte[]? timestampToken = null)
         {
+            // TODO: Implement timestampToken usage, right now is being ignored
+
             rangedStream.Position = 0;
 
             CmsSignedDataGenerator signedDataGenerator = new CmsSignedDataGenerator();
@@ -82,11 +84,6 @@ namespace PdfSharp.Pdf.Signatures
                 ECC => cert.GetECDsaPrivateKey(),
                 _ => throw new NotImplementedException(),
             };
-        }
-
-        public Byte[] GetSignedCms(Stream stream, Int32 pdfVersion, Byte[] timestampToken)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/BouncySigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/BouncySigner.cs
@@ -83,5 +83,10 @@ namespace PdfSharp.Pdf.Signatures
                 _ => throw new NotImplementedException(),
             };
         }
+
+        public Byte[] GetSignedCms(Stream stream, Int32 pdfVersion, Byte[] timestampToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
@@ -4,6 +4,7 @@
 #if WPF
 using System.IO;
 #endif
+using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 
@@ -16,6 +17,31 @@ namespace PdfSharp.Pdf.Signatures
         public DefaultSigner(X509Certificate2 Certificate)
         {
             this.Certificate = Certificate;
+        }
+
+        public byte[] GetSignedCms(Stream stream, int pdfVersion, byte[] timestampToken)
+        {
+            var range = new byte[stream.Length];
+
+            stream.Position = 0;
+            stream.Read(range, 0, range.Length);
+
+            var contentInfo = new ContentInfo(range);
+            SignedCms signedCms = new SignedCms(contentInfo, true);
+            CmsSigner signer = new CmsSigner(Certificate);
+
+            signer.UnsignedAttributes.Add(new Pkcs9SigningTime());
+
+            if (timestampToken != null)
+            {
+                AsnEncodedData timestampTokenAsnEncodedData = new AsnEncodedData(new Oid("1.2.840.113549.1.9.16.2.14"), timestampToken);
+                signer.UnsignedAttributes.Add(new CryptographicAttributeObject(new Oid("1.2.840.113549.1.9.16.2.14"), new AsnEncodedDataCollection(timestampTokenAsnEncodedData)));
+            }
+
+            signedCms.ComputeSignature(signer, false);
+            var bytes = signedCms.Encode();
+
+            return bytes;
         }
 
         public byte[] GetSignedCms(Stream stream, int pdfVersion)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
@@ -35,7 +35,7 @@ namespace PdfSharp.Pdf.Signatures
             if (timestampToken != null)
             {
                 AsnEncodedData timestampTokenAsnEncodedData = new AsnEncodedData(new Oid("1.2.840.113549.1.9.16.2.14"), timestampToken);
-                signer.UnsignedAttributes.Add(new CryptographicAttributeObject(new Oid("1.2.840.113549.1.9.16.2.14"), new AsnEncodedDataCollection(timestampTokenAsnEncodedData)));
+                signer.SignedAttributes.Add(new CryptographicAttributeObject(new Oid("1.2.840.113549.1.9.16.2.14"), new AsnEncodedDataCollection(timestampTokenAsnEncodedData)));
             }
 
             signedCms.ComputeSignature(signer, true);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/DefaultSigner.cs
@@ -19,7 +19,7 @@ namespace PdfSharp.Pdf.Signatures
             this.Certificate = Certificate;
         }
 
-        public byte[] GetSignedCms(Stream stream, int pdfVersion, byte[] timestampToken)
+        public byte[] GetSignedCms(Stream stream, int pdfVersion, byte[]? timestampToken = null)
         {
             var range = new byte[stream.Length];
 
@@ -37,25 +37,6 @@ namespace PdfSharp.Pdf.Signatures
                 AsnEncodedData timestampTokenAsnEncodedData = new AsnEncodedData(new Oid("1.2.840.113549.1.9.16.2.14"), timestampToken);
                 signer.UnsignedAttributes.Add(new CryptographicAttributeObject(new Oid("1.2.840.113549.1.9.16.2.14"), new AsnEncodedDataCollection(timestampTokenAsnEncodedData)));
             }
-
-            signedCms.ComputeSignature(signer, false);
-            var bytes = signedCms.Encode();
-
-            return bytes;
-        }
-
-        public byte[] GetSignedCms(Stream stream, int pdfVersion)
-        {
-            var range = new byte[stream.Length];
-
-            stream.Position = 0;
-            stream.Read(range, 0, range.Length);
-
-            var contentInfo = new ContentInfo(range);
-
-            SignedCms signedCms = new SignedCms(contentInfo, true);
-            CmsSigner signer = new CmsSigner(Certificate);
-            signer.UnsignedAttributes.Add(new Pkcs9SigningTime());
 
             signedCms.ComputeSignature(signer, true);
             var bytes = signedCms.Encode();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/ISigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/ISigner.cs
@@ -9,8 +9,7 @@ namespace PdfSharp.Pdf.Signatures
 {
     public interface ISigner
     {
-        byte[] GetSignedCms(Stream stream, int pdfVersion);
-        byte[] GetSignedCms(Stream stream, int pdfVersion, byte[] timestampToken);
+        byte[] GetSignedCms(Stream stream, int pdfVersion, byte[]? timestampToken = null);
 
         string GetName();
     }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/ISigner.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/ISigner.cs
@@ -10,6 +10,7 @@ namespace PdfSharp.Pdf.Signatures
     public interface ISigner
     {
         byte[] GetSignedCms(Stream stream, int pdfVersion);
+        byte[] GetSignedCms(Stream stream, int pdfVersion, byte[] timestampToken);
 
         string GetName();
     }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/PdfSignatureHandler.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/PdfSignatureHandler.cs
@@ -21,7 +21,7 @@ namespace PdfSharp.Pdf.Signatures
     {
         private PdfString signatureFieldContentsPdfString;
         private PdfArray signatureFieldByteRangePdfArray;
-        private byte[] timestampToken;
+        private byte[]? timestampToken;
 
         /// <summary>
         /// Cache signature length (bytes) for each PDF version since digest length depends on digest algorithm that depends on PDF version.
@@ -56,19 +56,7 @@ namespace PdfSharp.Pdf.Signatures
                 knownSignatureLengthInBytesByPdfVersion[documentToSign.Version] = signer.GetSignedCms(new MemoryStream(new byte[] { 0 }), documentToSign.Version, timestampToken).Length;
         }
 
-        public PdfSignatureHandler(ISigner signer, PdfSignatureOptions options)
-        {
-            ArgumentNullException.ThrowIfNull(signer);
-            ArgumentNullException.ThrowIfNull(options);
-
-            if (options.PageIndex < 0)
-                throw new ArgumentOutOfRangeException($"Signature page index cannot be negative.");
-
-            this.signer = signer;
-            this.Options = options;
-        }
-
-        public PdfSignatureHandler(ISigner signer, PdfSignatureOptions options, byte[] timestampToken)
+        public PdfSignatureHandler(ISigner signer, PdfSignatureOptions options, byte[]? timestampToken = null)
         {
             if (signer is null)
                 throw new ArgumentNullException(nameof(signer));

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/PdfSignatureHandler.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Signatures/PdfSignatureHandler.cs
@@ -21,6 +21,7 @@ namespace PdfSharp.Pdf.Signatures
     {
         private PdfString signatureFieldContentsPdfString;
         private PdfArray signatureFieldByteRangePdfArray;
+        private byte[] timestampToken;
 
         /// <summary>
         /// Cache signature length (bytes) for each PDF version since digest length depends on digest algorithm that depends on PDF version.
@@ -52,7 +53,7 @@ namespace PdfSharp.Pdf.Signatures
 
             // estimate signature length by computing signature for a fake byte[]
             if (!knownSignatureLengthInBytesByPdfVersion.ContainsKey(documentToSign.Version))
-                knownSignatureLengthInBytesByPdfVersion[documentToSign.Version] = signer.GetSignedCms(new MemoryStream(new byte[] { 0 }), documentToSign.Version).Length;
+                knownSignatureLengthInBytesByPdfVersion[documentToSign.Version] = signer.GetSignedCms(new MemoryStream(new byte[] { 0 }), documentToSign.Version, timestampToken).Length;
         }
 
         public PdfSignatureHandler(ISigner signer, PdfSignatureOptions options)
@@ -65,6 +66,21 @@ namespace PdfSharp.Pdf.Signatures
 
             this.signer = signer;
             this.Options = options;
+        }
+
+        public PdfSignatureHandler(ISigner signer, PdfSignatureOptions options, byte[] timestampToken)
+        {
+            if (signer is null)
+                throw new ArgumentNullException(nameof(signer));
+            if (options is null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (options.PageIndex < 0)
+                throw new ArgumentOutOfRangeException($"Signature page index cannot be negative.");
+
+            this.signer = signer;
+            this.Options = options;
+            this.timestampToken = timestampToken;
         }
 
         private void ComputeSignatureAndRange(object sender, PdfDocumentEventArgs e)
@@ -84,7 +100,7 @@ namespace PdfSharp.Pdf.Signatures
 
             // computing and writing document's digest
 
-            var signature = signer.GetSignedCms(rangedStreamToSign, Document.Version);
+            var signature = signer.GetSignedCms(rangedStreamToSign, Document.Version, timestampToken);
 
             if (signature.Length != knownSignatureLengthInBytesByPdfVersion[Document.Version])
                 throw new Exception("The digest length is different that the approximation made.");


### PR DESCRIPTION
This PR introduces timestamp support in PDFSharp-extended's signature handling.

**Key Changes:**
- Added `GetSignedCms` method in `DefaultSigner` and `BouncySigner` (**TODO**) to support timestamp tokens.
- Updated `PdfSignatureHandler` to process signatures with optional timestamp tokens.
- Modified `ISigner` interface to accommodate the new method signature.

**Benefits:**
These enhancements enable the creation of verifiably timestamped signatures in PDF documents, meeting requirements for document integrity and authenticity in sensitive use cases.

**Motivation:**
Identified the need for timestamped signatures in a project and implemented this feature to fill the gap, hoping to contribute a valuable addition to the PDFSharp community.

I'm new to C# and open-source contributions and look forward to feedback and suggestions to refine this feature.

Thank you.
